### PR TITLE
Rv/infer raw

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+speech/flags.go

--- a/speech/detector.go
+++ b/speech/detector.go
@@ -251,7 +251,7 @@ func (sd *Detector) Detect(pcm []float32) ([]Segment, error) {
 	return segments, nil
 }
 
-func (sd *Detector) DetectWindows(pcm []float32) ([]bool, error) {
+func (sd *Detector) DetectWindows(pcm []float32) ([]float32, error) {
 	if sd == nil {
 		return nil, fmt.Errorf("invalid nil detector")
 	}
@@ -269,15 +269,14 @@ func (sd *Detector) DetectWindows(pcm []float32) ([]bool, error) {
 		return nil, fmt.Errorf("samples must be in increments of %d, got %d (remainder %d)", windowSize, len(pcm), len(pcm)%windowSize)
 	}
 
-	// simpler w/ binary outcomes over direct probabilities
-	windows := make([]bool, len(pcm)/windowSize)
+	windows := make([]float32, len(pcm)/windowSize)
 
 	for i := 0; i < len(windows); i++ {
 		speechProb, err := sd.Infer(pcm[i*windowSize : (i+1)*windowSize])
 		if err != nil {
 			return nil, fmt.Errorf("infer failed: %w", err)
 		}
-		windows[i] = speechProb > sd.cfg.Threshold
+		windows[i] = speechProb
 	}
 	return windows, nil
 }

--- a/speech/detector.go
+++ b/speech/detector.go
@@ -251,7 +251,7 @@ func (sd *Detector) Detect(pcm []float32) ([]Segment, error) {
 	return segments, nil
 }
 
-func (sd *Detector) DetectWindows(pcm []float32) ([]float32, error) {
+func (sd *Detector) DetectWindows(pcm []float32) ([]bool, error) {
 	if sd == nil {
 		return nil, fmt.Errorf("invalid nil detector")
 	}
@@ -269,14 +269,15 @@ func (sd *Detector) DetectWindows(pcm []float32) ([]float32, error) {
 		return nil, fmt.Errorf("samples must be in increments of %d, got %d (remainder %d)", windowSize, len(pcm), len(pcm)%windowSize)
 	}
 
-	windows := make([]float32, len(pcm)/windowSize)
+	// simpler w/ binary outcomes over direct probabilities
+	windows := make([]bool, len(pcm)/windowSize)
 
 	for i := 0; i < len(windows); i++ {
 		speechProb, err := sd.Infer(pcm[i*windowSize : (i+1)*windowSize])
 		if err != nil {
 			return nil, fmt.Errorf("infer failed: %w", err)
 		}
-		windows[i] = speechProb
+		windows[i] = speechProb > sd.cfg.Threshold
 	}
 	return windows, nil
 }


### PR DESCRIPTION
- Added `DetectWindows` method to expose raw speech probabilities for windows of bytes
    - Maintains exact byte indices
    - Enables improvements for auto-calibration, lookahead/lookback buffers, etc.